### PR TITLE
feat(ci): add a required dependency review workflows

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -93,7 +93,7 @@ jobs:
       pull-requests: write
 
     with:
-      runs-on: "ubuntu-latest"
+      runs-on: '["ubuntu-latest"]'
       retry-on-snapshot-warnings: true
       retry-on-snapshot-warnings-timeout: 120
 
@@ -111,4 +111,4 @@ jobs:
     uses: coveo/public-actions/.github/workflows/dependency-review-v2.yml@main
 
     with:
-      runs-on: "ubuntu-latest"
+      runs-on: '["ubuntu-latest"]'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,114 @@
+name: 'Dependency Review'
+
+on: pull_request
+
+permissions: { }
+
+jobs:
+  detect-build-tool:
+    name: Detect Build Tool
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    outputs:
+      is-maven: ${{ steps.check_maven.outputs.is-maven }}
+      is-gradle: ${{ steps.check_gradle.outputs.is-gradle }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Check for Maven
+        id: check_maven
+        run: echo "is-maven=$(test -f pom.xml && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - name: Check for Gradle
+        id: check_gradle
+        run: echo "is-gradle=$(test -f build.gradle || test -f build.gradle.kts && echo true || echo false)" >> $GITHUB_OUTPUT
+
+  dependency-review-maven:
+    needs: detect-build-tool
+
+    if: needs.detect-build-tool.outputs.is-maven == 'true'
+
+    name: Dependency Review - Maven
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    uses: coveo/public-actions/.github/workflows/java-maven-openjdk-dependency-review.yml@main
+    with:
+      runs-on: "ubuntu-latest"
+
+  dependency-submit-gradle:
+    needs: detect-build-tool
+
+    if: needs.detect-build-tool.outputs.is-gradle == 'true'
+
+    name: Dependency Submit - Gradle
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ vars.JAVA_VERSION || 21 }}
+
+      - name: Check gradle wrapper
+        id: check_gradle_wrapper
+        run: echo "has-gradle-wrapper=$(test -f gradlew && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - name: Generate and submit dependency graph with wrapper
+        if: steps.check_gradle_wrapper.outputs.has-gradle-wrapper == 'true'
+        uses: gradle/actions/dependency-submission@v4
+
+      - name: Generate and submit dependency graph
+        if: steps.check_gradle_wrapper.outputs.has-gradle-wrapper == 'false'
+        uses: gradle/actions/dependency-submission@v4
+        with:
+          # Use a particular Gradle version instead of the configured wrapper.
+          gradle-version: 8.11
+
+  dependency-review-gradle:
+    needs: dependency-submit-gradle
+
+    name: Dependency Review - Gradle
+
+    uses: coveo/public-actions/.github/workflows/dependency-review-v2.yml@main
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    with:
+      runs-on: "ubuntu-latest"
+      retry-on-snapshot-warnings: true
+      retry-on-snapshot-warnings-timeout: 120
+
+  dependency-review-generic:
+    needs: detect-build-tool
+
+    if: needs.detect-build-tool.outputs.is-maven == 'false' && needs.detect-build-tool.outputs.is-gradle == 'false'
+
+    name: Dependency Review - Generic
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    uses: coveo/public-actions/.github/workflows/dependency-review-v2.yml@main
+
+    with:
+      runs-on: "ubuntu-latest"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # required-public-workflows
 
 Centralized repository for required GitHub Actions workflows applied across all repositories in the coveops organization. Ensures consistent standards, security, and best practices for CI/CD and code management.
+
+## Dependency Review
+
+This repository contains the Dependency Review workflows used for the entire organization. That workflow is invoked by a Ruleset.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # required-public-workflows
+
 Centralized repository for required GitHub Actions workflows applied across all repositories in the coveops organization. Ensures consistent standards, security, and best practices for CI/CD and code management.


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for dependency review and updates the `README.md` file to document the addition. The workflow supports Maven and Gradle projects, as well as a generic fallback for other cases, ensuring comprehensive dependency management across repositories.

### New GitHub Actions Workflow for Dependency Review:

* [`.github/workflows/dependency-review.yml`](diffhunk://#diff-7cdd3ccec44c8ba176bdc3b9ef54c3f56aa210a1a4e2bb5f79d87b1e50314a18R1-R114): Added a workflow to perform dependency reviews. It detects the build tool (Maven or Gradle) and executes corresponding dependency review steps. For Gradle, it includes logic to handle projects with or without a Gradle wrapper. A generic fallback is provided for repositories without Maven or Gradle.

### Documentation Update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R2-R7): Updated to include a description of the new Dependency Review workflow, emphasizing its role in maintaining consistent standards across the organization.